### PR TITLE
Allow authors to redirect to edit page AND constructing edit link for pages having parent page

### DIFF
--- a/php/page.php
+++ b/php/page.php
@@ -4,7 +4,7 @@
 		<div class="col-lg-10 col-xl-8 mr-auto ml-auto">
 			<?php Theme::plugins('pageBegin'); ?>
 			<article class="post-wrap <?php echo $page->sticky() ? 'featured':''; ?>">
-				<?php if($login->isLogged()) if($canEdit = checkRole(array('admin', 'editor'))):?>
+				<?php if($login->isLogged()) if($canEdit = checkRole(array('admin', 'editor', 'author'))):?>
 				<a href="<?php echo HTML_PATH_ADMIN_ROOT.'edit-content/'.$page->slug() ?>" class="article-edit" target="_blank">
 					<span>Edit</span>
 					<i class="icon-arrow-right"></i>

--- a/php/page.php
+++ b/php/page.php
@@ -5,7 +5,7 @@
 			<?php Theme::plugins('pageBegin'); ?>
 			<article class="post-wrap <?php echo $page->sticky() ? 'featured':''; ?>">
 				<?php if($login->isLogged()) if($canEdit = checkRole(array('admin', 'editor', 'author'))):?>
-				<a href="<?php echo HTML_PATH_ADMIN_ROOT.'edit-content/'.$page->slug() ?>" class="article-edit" target="_blank">
+				<a href="<?php echo HTML_PATH_ADMIN_ROOT.'edit-content/'.$page->key() ?>" class="article-edit" target="_blank">
 					<span>Edit</span>
 					<i class="icon-arrow-right"></i>
 				</a>


### PR DESCRIPTION
There are two issues:

1. Currently if logged in user with author privileges clicks on edit button in page, then that user is getting redirected to dashboard with privileges error.
1. If we have a page which is having parent page, then the edit link is not constructing properly
